### PR TITLE
Rating Calculations and Score Fixes

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -4200,12 +4200,12 @@ class PlayState extends MusicBeatState
 
 		//tryna do MS based judgment due to popular demand
 		var daRating:Rating = Conductor.judgeNote(note, noteDiff);
-		var ratingNum:Int = 0;
 
 		totalNotesHit += daRating.ratingMod;
 		note.ratingMod = daRating.ratingMod;
 		if(!note.ratingDisabled) daRating.increase();
 		note.rating = daRating.name;
+		score = daRating.score;
 
 		if(daRating.noteSplash && !note.noteSplashDisabled)
 		{

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -5322,8 +5322,6 @@ class PlayState extends MusicBeatState
 		setOnLuas('misses', songMisses);
 		setOnLuas('hits', songHits);
 
-		updateScore(badHit); // miss notes shouldn't make the scoretxt bounce -Ghost
-
 		var ret:Dynamic = callOnLuas('onRecalculateRating', [], false);
 		if(ret != FunkinLua.Function_Stop)
 		{
@@ -5361,6 +5359,7 @@ class PlayState extends MusicBeatState
 			if (songMisses > 0 && songMisses < 10) ratingFC = "SDCB";
 			else if (songMisses >= 10) ratingFC = "Clear";
 		}
+		updateScore(badHit); // miss notes shouldn't make the scoretxt bounce -Ghost
 		setOnLuas('rating', ratingPercent);
 		setOnLuas('ratingName', ratingName);
 		setOnLuas('ratingFC', ratingFC);


### PR DESCRIPTION
this fixes some issues from psych engine, the scorebar should now update as soon as you hit a note, but as soon as the rating is properly calculated, and they should also follow score rules, means that sick gives 350 score, good gives 200, etc

wrong rating calcs was caused by me on the base repository for Psych Engine, still an issue, but it's not a priority to fix it rn, however here's a fix for it